### PR TITLE
IG-22117: Fix extracting fuse container uid from /proc/self/cgroup

### DIFF
--- a/pkg/cri/containerd.go
+++ b/pkg/cri/containerd.go
@@ -180,7 +180,25 @@ func (c *Containerd) createContainer(image string,
 	targetPath string,
 	args []string) (containerd.Container, error) {
 
-	args = append(args, " 2>&1 | multilog s16777215 n20 /var/log/containers/flex-fuse-`cat /proc/self/cgroup |  head -n 1 | awk -F  \"/\"  '{print $NF}'`")
+	// The log file name contains the container-ID which appears in /proc/self/cgroup file as a sequence of 64 hexadecimal digits
+	// root@gke-zd-gke1-app-clust-zd-gke1-initial-7b135c73-jxn0:/#  cat /proc/self/cgroup
+	// 13:misc:/
+	// 12:rdma:/
+	// 11:memory:/kubepods/besteffort/pod0404f9f9-7e8f-4cf0-848a-a7a23ef63393/466f13d55e758cf1e969744007435e2eb3d48f4d64f81fa7f2c2c7ac14690c23
+	// 10:freezer:/kubepods/besteffort/pod0404f9f9-7e8f-4cf0-848a-a7a23ef63393/466f13d55e758cf1e969744007435e2eb3d48f4d64f81fa7f2c2c7ac14690c23
+	// 9:cpuset:/kubepods/besteffort/pod0404f9f9-7e8f-4cf0-848a-a7a23ef63393/466f13d55e758cf1e969744007435e2eb3d48f4d64f81fa7f2c2c7ac14690c23
+	// 8:pids:/kubepods/besteffort/pod0404f9f9-7e8f-4cf0-848a-a7a23ef63393/466f13d55e758cf1e969744007435e2eb3d48f4d64f81fa7f2c2c7ac14690c23
+	// 7:blkio:/kubepods/besteffort/pod0404f9f9-7e8f-4cf0-848a-a7a23ef63393/466f13d55e758cf1e969744007435e2eb3d48f4d64f81fa7f2c2c7ac14690c23
+	// 6:perf_event:/kubepods/besteffort/pod0404f9f9-7e8f-4cf0-848a-a7a23ef63393/466f13d55e758cf1e969744007435e2eb3d48f4d64f81fa7f2c2c7ac14690c23
+	// 5:net_cls,net_prio:/kubepods/besteffort/pod0404f9f9-7e8f-4cf0-848a-a7a23ef63393/466f13d55e758cf1e969744007435e2eb3d48f4d64f81fa7f2c2c7ac14690c23
+	// 4:cpu,cpuacct:/kubepods/besteffort/pod0404f9f9-7e8f-4cf0-848a-a7a23ef63393/466f13d55e758cf1e969744007435e2eb3d48f4d64f81fa7f2c2c7ac14690c23
+	// 3:devices:/kubepods/besteffort/pod0404f9f9-7e8f-4cf0-848a-a7a23ef63393/466f13d55e758cf1e969744007435e2eb3d48f4d64f81fa7f2c2c7ac14690c23
+	// 2:hugetlb:/kubepods/besteffort/pod0404f9f9-7e8f-4cf0-848a-a7a23ef63393/466f13d55e758cf1e969744007435e2eb3d48f4d64f81fa7f2c2c7ac14690c23
+	// 1:name=systemd:/kubepods/besteffort/pod0404f9f9-7e8f-4cf0-848a-a7a23ef63393/466f13d55e758cf1e969744007435e2eb3d48f4d64f81fa7f2c2c7ac14690c23
+	// 0::/system.slice/containerd.service
+	// root@gke-zd-gke1-app-clust-zd-gke1-initial-7b135c73-jxn0:/#
+
+	args = append(args, " 2>&1 | multilog s16777215 n20 /var/log/containers/flex-fuse-`cat /proc/self/cgroup | awk 'match($0, /[0-9a-fA-F]{64}/) { if (RSTART > 0) { print substr($0, RSTART, RLENGTH); exit; } }'`")
 
 	journal.Debug("Creating container",
 		"image", image,


### PR DESCRIPTION
In this latest fix for generating the FUSE log filename, we're not focusing on a specific line of text. Instead, we're searching for the first occurrence of a 64-character hexadecimal sequence. This approach aims to be compatible with both cgroup and cgroup2 scenarios