### PR TITLE
Bump Go version to 1.24.13 to fix CVE-2025-6172 and CVE-2025-6173

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM golang:1.24.11 AS builder
+FROM golang:1.24.13 AS builder
 
 ENV PROJECT_PATH=/flex-fuse
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/v3io/flex-fuse
 
 go 1.24
 
-toolchain go1.24.11
+toolchain go1.24.13
 
 require (
 	github.com/containerd/containerd v1.7.29


### PR DESCRIPTION
## Summary
- Upgrade Go from 1.24.11 to 1.24.13 in Dockerfile and go.mod
- Fixes CVE-2025-6172 and CVE-2025-6173 (fixed in Go 1.24.12 and 1.24.13)

## Test plan
- [ ] Verify Docker image builds successfully with Go 1.24.13
- [ ] Run `make build` to confirm no regressions