### PR TITLE
Disable BuildKit to fix docker build on older kernels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ DEB_PATH = iguazio_deb
 
 .PHONY: build
 build:
-	docker build --progress=plain --tag flex-fuse:unstable .
+	DOCKER_BUILDKIT=0 docker build --progress=plain --tag flex-fuse:unstable .
 
 .PHONY: download
 download:


### PR DESCRIPTION
## Summary
- `golang:1.24` Debian base introduced a filesystem path that BuildKit's cache-key walker cannot handle on older kernel versions
- Prefixing the docker build command with `DOCKER_BUILDKIT=0` falls back to the classic builder, avoiding the issue
- Applied at the Makefile level to avoid affecting other builds on the nodes that rely on BuildKit

See slack discussion https://iguazio.slack.com/archives/C6J593VNU/p1776154162426729
